### PR TITLE
Fix cli params for mysqld

### DIFF
--- a/snap/local/start-mysqld.sh
+++ b/snap/local/start-mysqld.sh
@@ -7,9 +7,10 @@ if [ ! -f "${CONFIG_DIR}/initialized" ]; then
         echo "copying default config to ${CONFIG_DIR}"
         cp -r $SNAP/etc/mysql $SNAP_COMMON
         sed -i "s:/var/run/mysqld/mysqld.sock:$SNAP_COMMON/mysqld.sock:g" $SNAP_COMMON/mysql/mysql.conf.d/mysqld.cnf
+        sed -i "s: mysql: root:g" $SNAP_COMMON/mysql/mysql.conf.d/mysqld.cnf
         sed -i "s:# sock:sock:g" $SNAP_COMMON/mysql/mysql.conf.d/mysqld.cnf
         sed -i "s:/var/log/mysql/error.log:$SNAP_COMMON/error.log:g" $SNAP_COMMON/mysql/mysql.conf.d/mysqld.cnf
         touch $CONFIG_DIR/initialized
 fi
 
-$SNAP/usr/sbin/mysqld --defaults-file=$SNAP_COMMON/mysql/mysql.conf.d/mysqld.cnf
+$SNAP/usr/sbin/mysqld --defaults-file=$SNAP_COMMON/mysql/mysql.conf.d/mysqld.cnf --user=root


### PR DESCRIPTION
# Issue
<!-- What issue is this PR trying to solve? -->
mysqld fails to start because of permissions issues to $SNAP_DATA and $SNAP_COMMON.


# Solution
<!-- A summary of the solution addressing the above issue -->
This PR runs mysqld as root for the time being to allow access to those directories

# Context
<!-- What is some specialized knowledge relevant to this project/technology -->
mysqld handles configuration in the mysqld.cnf file under `$SNAP_COMMON/mysql/mysqld.conf.d/mysqld.cnf`, but to run as root, the `--user=root` flag needs to be added to the cli params.


# Testing
<!-- What steps need to be taken to test this PR? -->
This change was tested locally and manually.  This can be automated once integration tests are created.


# Release Notes
<!-- A digestable summary of the change in this PR -->
Add `--user=root` CLI arg to the `start_mysqld.sh` script.